### PR TITLE
Update Dockerfile to use sharelatex 4.2.9

### DIFF
--- a/sharelatex-ce/Dockerfile
+++ b/sharelatex-ce/Dockerfile
@@ -1,4 +1,4 @@
-FROM sharelatex/sharelatex:4.2.3
+FROM sharelatex/sharelatex:4.2.9
 
 RUN cd /tmp && \
     wget https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz && \


### PR DESCRIPTION
fix #2，sharelatex 4.2.3 现在会默认监听ipv6地址，修改成4.2.9可修复